### PR TITLE
KAS-977: removed unused code and variables

### DIFF
--- a/repository/BelgaFTPService.js
+++ b/repository/BelgaFTPService.js
@@ -1,82 +1,41 @@
-const ftpClient = require('ftp');
-const fs = require('fs');
-const xml = require('xml');
-// const config = require('./config');
-const repository = require('./index.js');
-const xmlConfig = require('../xml-renderer/config.js');
-const helper = require('../repository/helpers');
+// const ftpClient = require('ftp');
+const fs = require("fs");
+const xml = require("xml");
+const repository = require("./index.js");
+const xmlConfig = require("../xml-renderer/config.js");
+const helper = require("../repository/helpers");
 
-const user = 'vlatest';
-const password = 'alvalv';
-const host = 'ftp.belga.be';
-const port = 21; // this is the default port for FTP
-import moment from 'moment';
-let client;
+import moment from "moment";
 
 export default class BelgaService {
-  constructor() {
-    // client = new ftpClient();
-    // client.on('ready', function() {
-    // 	client.list(function(err, list) {
-    // 		if (err) throw err;
-    // 		console.dir(list);
-    // 		client.end();
-    // 	});
-    // });
-    // this.connectToClient();
-  }
-
-  connectToClient() {
-    const config = { host, port, password, user };
-
-    // client.connect(config);
-  }
-
-  getRepository() {}
-
-  checkDocumentExistence() {}
-
-  uploadFile() {}
-
-  deleteFile() {}
-
-  normalizeId() {}
-
-  formatDutchDate() {}
-
-  deNormelizeId() {}
-
   async generateXML(agendaId) {
-    const {
-      formattedStart,
-      publication_date,
-      agendaURI,
-    } = await repository.getAgendaNewsletterInformation(agendaId);
+    console.time('FETCH BELGA INFORMATION TIME');
+    const { formattedStart, publication_date, agendaURI } = await repository.getAgendaNewsletterInformation(agendaId);
     const data = await repository.getNewsLetterByAgendaId(agendaURI);
     const content = await createNewsletterString(data);
-
+    console.timeEnd('FETCH BELGA INFORMATION TIME');
     const sentAt = moment
       .utc()
-      .utcOffset('+02:00')
-      .format('YYYYMMDDTHHmmssZZ');
+      .utcOffset("+02:00")
+      .format("YYYYMMDDTHHmmssZZ");
 
     const escapedContent = escapeHtml(`<![CDATA[ Body content: ${content} ]]>`);
 
-    const identicationDate = moment(publication_date).format('YYYYMMDD');
+    const identicationDate = moment(publication_date).format("YYYYMMDD");
     const XMLCONFIG = xmlConfig.createXMLConfig(escapedContent, sentAt, identicationDate);
     const xmlString = xml(XMLCONFIG, { declaration: true });
     const path = `${__dirname}/../generated-xmls/Beslissingen_van_de_ministerraad_van_${formattedStart}.xml`;
-
+    
     const output = fs.createWriteStream(path);
     output.write(xmlString);
     return new Promise((resolve, reject) => {
-      output.on('open', function(fd) {
-        console.log('file is open!');
-        console.log('fd: ' + fd);
+      output.on("open", function(fd) {
+        console.log("file is open!");
+        console.log("fd: " + fd);
         resolve(path);
       });
 
-      output.on('error', function(err) {
+      output.on("error", function(err) {
         reject(err);
       });
     });
@@ -94,22 +53,19 @@ const createNewsletterString = (data) => {
   reducedNewsletters.map((newsletterItem) => {
     agendaitems.push(
       `<p>
-      ${newsletterItem.title || ''}
-      ${newsletterItem.proposal || ''}
-      ${newsletterItem.richtext || ''}
+      ${newsletterItem.title || ""}
+      ${newsletterItem.proposal || ""}
+      ${newsletterItem.richtext || ""}
       </p>`
-      .replace(/^\s+|\s+$/gm, '')
-      .replace(/(?=<!--)([\s\S]*?)-->/gm, '')
-      .replace(/\n&nbsp;*/gm, '')
-      .trim()
+        .replace(/^\s+|\s+$/gm, "")
+        .replace(/(?=<!--)([\s\S]*?)-->/gm, "")
+        .replace(/\n&nbsp;*/gm, "")
+        .trim()
     );
   });
-  return agendaitems
-    .join(``)
+  return agendaitems.join(``);
 };
 
 function escapeHtml(unsafe) {
-  return unsafe
-       .replace(/"/g, "&quot;")
-       .replace(/'/g, "&#039;");
+  return unsafe.replace(/"/g, "&quot;").replace(/'/g, "&#039;");
 }


### PR DESCRIPTION
This config is required to be parsable.
In this feature I created a way to wrap every agenda item in a `<p></p>`-tag.