### PR TITLE
feature/KAS-1425 model refactor: Activity

### DIFF
--- a/repository/index.js
+++ b/repository/index.js
@@ -138,7 +138,7 @@ const getNewsLetterByAgendaId = async (agendaURI) => {
         SELECT ?title ?richtext (GROUP_CONCAT(?label;separator=",") AS ?themes) ?mandateeTitle ?mandateePriority ?newsletter ?mandateeName ?agendaitemPrio WHERE {
             GRAPH <${targetGraph}> {
               <${agendaURI}> dct:hasPart ?agendaitem . 
-              ?subcase besluitvorming:isGeagendeerdVia ?agendaitem .
+              ?subcase ^besluitvorming:vindtPlaatsTijdens / besluitvorming:genereertAgendapunt ?agendaitem .
               ?subcase prov:generated ?newsletter . 
               ?agendaitem ext:wordtGetoondAlsMededeling "false"^^xsd:boolean .
               ?agendaitem ext:prioriteit ?agendaitemPrio .


### PR DESCRIPTION
# :mag:  KAS-1425: Model refactor: activity model gebruiken
De refactor verlegt de relatie tussen procedurstap en agendaitem naar een tussenobject: de agendering-activiteit
Bij de refactor hoort ook een deel opkuis van: postponed, procedurestapfases en fasecodes.

## ✏️  What has changed

### repository/index.js:
Relatie tussen subcase en agendaitem ligt nu via agendering-activiteit 