### PR TITLE
Migration/kas 1422 models agendaitem subcase

### DIFF
--- a/repository/index.js
+++ b/repository/index.js
@@ -133,7 +133,7 @@ const getNewsLetterByAgendaId = async (agendaURI) => {
               ?agendaitem ext:prioriteit ?agendaitemPrio .
               ?newsletter ext:inNieuwsbrief "true"^^xsd:boolean .
               OPTIONAL { 
-                ?agendaitem besluitvorming:heeftBevoegdeVoorAgendapunt ?mandatee .
+                ?agendaitem ext:heeftBevoegdeVoorAgendapunt ?mandatee .
                 ?mandatee dct:title ?mandateeTitle .
                 ?mandatee mandaat:rangorde ?mandateePriority .
                 ?mandatee ext:nickName ?mandateeName . 


### PR DESCRIPTION
# KAS-1422: uiteentrekken van agendaitem / subcase modellen
In deze model refactor heb ik gekeken welke data we nog onnodige dupliceren op beide modellen en ook vergelijken hoe het in het nieuwe oslo model zit.
Hieruit is gebleken dat de duplicatie al fel verminderd is t.o.v. vroeger, toen het ticket aangemaakt geweest is.
Ik heb voornamelijk wat prefixen correct gezet, en verwijdert wat weg mocht.

## ✏️ What has changed
- heeftBevoegdeVoorAgendapunt => besluitvorming: naar ext: