### PR TITLE
Store working data in /data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,4 @@
 FROM semtech/mu-javascript-template:1.6.0
 LABEL maintainer="info@redpencil.io"
+
+RUN mkdir -p /data/generated-xmls/

--- a/repository/belga-service.js
+++ b/repository/belga-service.js
@@ -114,7 +114,7 @@ export default class BelgaService {
     const name = `Beslissingen_van_de_${kindOfmeetingLowerCase}_${procedureText || 'van'}_${formattedStart}.xml`
       .split(' ')
       .join('_');
-    const path = `/app/generated-xmls/${name}`;
+    const path = `/data/generated-xmls/${name}`;
 
     fs.writeFileSync(path, xmlString);
 


### PR DESCRIPTION
This should help work with newer templates.  It also makes it more feasible to mount working data locally in case it would be desired to inspect said data.