### PR TITLE
Feature/kas 3443 belga xml storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Add the following snippet to your `docker-compose.yml`:
 ```yml
   newsletter-service:
     image: kanselarij/newsletter-service
+    volumes:
+      - ./data/generated-xmls:/share
     logging: *default-logging
     restart: always
     labels:
@@ -29,6 +31,7 @@ The following environment variables have to be configured:
 | BELGA_FTP_USERNAME             | string | the username to login to the Belga server                    |
 | BELGA_FTP_PASSWORD             | string | the password to login to the Belga server                    |
 | BELGA_FTP_HOST                 | string | the Belga server to connect to. Default value 'ftp.belga.be' |
+| XML_STORAGE_PATH               | string | storage location of Belga xmls. Default value '/share'       |
 
 The service will fail if the environment variables are not defined properly.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Add the following snippet to your `docker-compose.yml`:
   newsletter-service:
     image: kanselarij/newsletter-service
     volumes:
-      - ./data/generated-xmls:/share
+      - ./data/generated-xmls:/data
     logging: *default-logging
     restart: always
     labels:
@@ -31,7 +31,7 @@ The following environment variables have to be configured:
 | BELGA_FTP_USERNAME             | string | the username to login to the Belga server                    |
 | BELGA_FTP_PASSWORD             | string | the password to login to the Belga server                    |
 | BELGA_FTP_HOST                 | string | the Belga server to connect to. Default value 'ftp.belga.be' |
-| XML_STORAGE_PATH               | string | storage location of Belga xmls. Default value '/share'       |
+| XML_STORAGE_PATH               | string | storage location of Belga xmls. Default value '/data'       |
 
 The service will fail if the environment variables are not defined properly.
 

--- a/repository/belga-service.js
+++ b/repository/belga-service.js
@@ -10,7 +10,7 @@ import xml from 'xml';
 const user = process.env.BELGA_FTP_USERNAME;
 const password = process.env.BELGA_FTP_PASSWORD;
 const host = process.env.BELGA_FTP_HOST || 'ftp.belga.be';
-const STORAGE_PATH = process.env.XML_STORAGE_PATH || `/share`;
+const STORAGE_PATH = process.env.XML_STORAGE_PATH || `/data`;
 
 export default class BelgaService {
 

--- a/repository/belga-service.js
+++ b/repository/belga-service.js
@@ -10,6 +10,7 @@ import xml from 'xml';
 const user = process.env.BELGA_FTP_USERNAME;
 const password = process.env.BELGA_FTP_PASSWORD;
 const host = process.env.BELGA_FTP_HOST || 'ftp.belga.be';
+const STORAGE_PATH = process.env.XML_STORAGE_PATH || `/share`;
 
 export default class BelgaService {
 
@@ -114,7 +115,7 @@ export default class BelgaService {
     const name = `Beslissingen_van_de_${kindOfmeetingLowerCase}_${procedureText || 'van'}_${formattedStart}.xml`
       .split(' ')
       .join('_');
-    const path = `/app/generated-xmls/${name}`;
+    const path = `${STORAGE_PATH}/${name}`;
 
     fs.writeFileSync(path, xmlString);
 


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-3443

Use mounted volume to store xml files.

Tested locally with test ftp.
Files are created in the mounted folder, creating the same file just overwrites so we only have the last sent one.
Sending to Belga kept working.

Is the env property needed? other services seem to do the same so was unsure and just ran with it.