### PR TITLE
KAS-3894: Fix mail campaign saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The service will fail if the environment variables are not defined properly.
 
 #### POST /mail-campaigns
 
-Create the mail campaign in Mailchimp
+Create the mail campaign in Mailchimp and create a corresponding mail-campaign resource in the triplestore.
 
 Example request body:
 ```javascript
@@ -55,9 +55,26 @@ Example request body:
   }
 }
 ```
+
+Example response body:
+
+``` javascript
+{
+  "data": {
+    "type": "mail-campaigns",
+    "id": "newly-generated-uuid",
+    "attributes": {
+      "web-id": 123456,
+      "archive-url": "http://archive-url",
+      "campaign-id": "campaign-id-from-mailchimp"
+    }
+  }
+}
+```
+
 #### POST /mail-campaigns/:id/send
 
-Send out the campaign to Mailchimp
+Send out the campaign to Mailchimp and set the sent-time in the database.
 
 _Note: this request will fail if no mails are sent (e.g. no subscribers for the selected theme)_
 
@@ -69,7 +86,7 @@ Optionally `fields['mail-campaigns']=html` can be passed as query param to get t
 
 #### DELETE /mail-campaigns/:id
 
-Delete a mail-campaign in Mailchimp
+Delete a mail-campaign in Mailchimp and from the database.
 
 #### POST /belga-newsletters
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Example response body:
 
 Send out the campaign to Mailchimp and set the sent-time in the database.
 
+_Note: this request expects Mailchimp's campaignId to be passed as ID, not the resource's UUID._
+
 _Note: this request will fail if no mails are sent (e.g. no subscribers for the selected theme)_
 
 #### GET /mail-campaigns/:id
@@ -84,9 +86,40 @@ Get details of the given mail campaign.
 
 Optionally `fields['mail-campaigns']=html` can be passed as query param to get the HTML content of the mail campaign.
 
+_Note: this request expects Mailchimp's campaignId to be passed as ID, not the resource's UUID._
+
+Example response body:
+
+``` javascript
+// If fields['mail-campaigns']=html is set as query param
+{
+  "data": {
+    "type": "mail-campaigns",
+    "id": "campaign-id-from-mailchimp",
+    "attributes": {
+      "html": "<p>The full html content goes here</p>"
+    }
+  }
+}
+// If fields['mail-campaigns']=html is NOT set as query param
+{
+  "data": {
+    "type": "mail-campaigns",
+    "id": "campaign-id-from-mailchimp",
+    "attributes": {
+      "create-time": "2023-03-14T10:00:00Z"
+      "web-id": 123456,
+      "archive-url": "http://archive-url",
+    }
+  }
+}
+```
+
 #### DELETE /mail-campaigns/:id
 
 Delete a mail-campaign in Mailchimp and from the database.
+
+_Note: this request expects Mailchimp's campaignId to be passed as ID, not the resource's UUID._
 
 #### POST /belga-newsletters
 

--- a/app.js
+++ b/app.js
@@ -1,5 +1,8 @@
 import { app, errorHandler } from 'mu';
-import { getAgendaInformationForNewsletter } from './util/query-helper';
+import {
+  createMailCampaign,
+  getAgendaInformationForNewsletter,
+} from './util/query-helper';
 import BelgaService from './repository/belga-service';
 import MailchimpService from './repository/mailchimp-service';
 
@@ -50,14 +53,16 @@ app.post('/mail-campaigns', async function (req, res, next) {
     const agendaInformationForNewsLetter = await getAgendaInformationForNewsletter(meetingId);
     const campaign = await mailchimpService.prepareCampaign(agendaInformationForNewsLetter);
 
+    const campaignUuid = await createMailCampaign(agendaInformationForNewsLetter.meetingURI, campaign);
+
     res.status(201).send({
       data: {
         type: 'mail-campaigns',
-        id: campaign.campaignId,
+        id: campaignUuid,
         attributes: {
-          'create-time': campaign.create_time,
           'web-id': campaign.web_id,
-          'archive-url': campaign.archive_url
+          'archive-url': campaign.archive_url,
+          'campaign-id': campaign.campaignId,
         }
       },
       relationships: {

--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@ import { app, errorHandler } from 'mu';
 import {
   createMailCampaign,
   getAgendaInformationForNewsletter,
+  updateMailCampaignSentTime,
 } from './util/query-helper';
 import BelgaService from './repository/belga-service';
 import MailchimpService from './repository/mailchimp-service';
@@ -91,6 +92,7 @@ app.post('/mail-campaigns/:id/send', async (req, res, next) => {
     }
     console.log(`Sending MailChimp campaign ${campaignId}`);
     await mailchimpService.sendCampaign(campaignId);
+    await updateMailCampaignSentTime(campaignId, new Date());
     res.status(204).send();
   } catch (error) {
     console.log(`A problem occured when sending campaign in Mailchimp.`);

--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ import {
 import BelgaService from './repository/belga-service';
 import MailchimpService from './repository/mailchimp-service';
 
+const cacheClearTimeout = 2000;
 const requiredEnvironmentVariables = [
   'MAILCHIMP_API',
   'MAILCHIMP_FROM_NAME',
@@ -94,7 +95,9 @@ app.post('/mail-campaigns/:id/send', async (req, res, next) => {
     console.log(`Sending MailChimp campaign ${campaignId}`);
     await mailchimpService.sendCampaign(campaignId);
     await updateMailCampaignSentTime(campaignId, new Date());
-    res.status(204).send();
+    setTimeout(() => {
+      res.status(204).send();
+    }, cacheClearTimeout);
   } catch (error) {
     console.log(`A problem occured when sending campaign in Mailchimp.`);
     logErrorResponse(error);
@@ -165,7 +168,9 @@ app.delete('/mail-campaigns/:id', async (req, res, next) => {
     } else {
       await mailchimpService.deleteCampaign(campaignId);
       await deleteMailCampaign(campaignId);
-      res.status(204).send();
+      setTimeout(() => {
+        res.status(204).send();
+      }, cacheClearTimeout);
     }
   } catch (error) {
     console.log(`A problem occured when deleting campaign ${campaignId} in Mailchimp.`);

--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 import { app, errorHandler } from 'mu';
 import {
   createMailCampaign,
+  deleteMailCampaign,
   getAgendaInformationForNewsletter,
   updateMailCampaignSentTime,
 } from './util/query-helper';
@@ -163,6 +164,7 @@ app.delete('/mail-campaigns/:id', async (req, res, next) => {
       next(error);
     } else {
       await mailchimpService.deleteCampaign(campaignId);
+      await deleteMailCampaign(campaignId);
       res.status(204).send();
     }
   } catch (error) {

--- a/repository/mailchimp-service.js
+++ b/repository/mailchimp-service.js
@@ -22,6 +22,10 @@ export default class MailchimpService {
       });
   }
 
+  async wait(durationInMs) {
+    return new Promise(resolve => setTimeout(resolve, durationInMs));
+  }
+
   async ping() {
     const response = await mailchimpConnection.ping.get();
 

--- a/util/query-helper.js
+++ b/util/query-helper.js
@@ -192,6 +192,20 @@ export async function updateMailCampaignSentTime(mailCampaignId, sentTime) {
     }`);
 }
 
+export async function deleteMailCampaign(mailCampaignId) {
+  console.log(`Deleting mail campaign with id ${mailCampaignId}`);
+
+  return await update(`
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+    DELETE WHERE {
+      ?mailCampaign a ext:MailCampagne ;
+        ext:campagneId ${sparqlEscapeString(mailCampaignId)} ;
+        ?p ?o .
+      ?s ?pp ?mailCampaign .
+    }`);
+}
+
 async function getMeetingURI (meetingId) {
   console.log(`Get meetingURI for meeting ${meetingId}`);
   const meetingUriQuery = await query(`

--- a/util/query-helper.js
+++ b/util/query-helper.js
@@ -5,6 +5,7 @@ import { reduceNewslettersToMandateesByPriority } from '../util/newsletter-helpe
 import {
   sparqlEscapeString,
   sparqlEscapeUri,
+  sparqlEscapeDateTime,
   query,
   update,
   uuid,
@@ -176,6 +177,19 @@ export async function createMailCampaign(meetingUri, mailCampaign) {
         ext:voorbeeldUrl ${sparqlEscapeString(archiveUrl)} .
     }`);
   return id;
+}
+
+export async function updateMailCampaignSentTime(mailCampaignId, sentTime) {
+  console.log(`Updating mail campaign sent time with id ${mailCampaignId}`);
+
+  return await update(`
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+    INSERT { ?mailCampaign ext:isVerstuurdOp ${sparqlEscapeDateTime(sentTime)} }
+    WHERE {
+      ?mailCampaign a ext:MailCampagne ;
+        ext:campagneId ${sparqlEscapeString(mailCampaignId)} .
+    }`);
 }
 
 async function getMeetingURI (meetingId) {

--- a/util/query-helper.js
+++ b/util/query-helper.js
@@ -2,7 +2,13 @@ import moment from 'moment';
 import 'moment-timezone';
 import { getNewsItem } from './html';
 import { reduceNewslettersToMandateesByPriority } from '../util/newsletter-helper';
-import { sparqlEscapeString, sparqlEscapeUri, query } from 'mu';
+import {
+  sparqlEscapeString,
+  sparqlEscapeUri,
+  query,
+  update,
+  uuid,
+} from 'mu';
 
 moment.locale('nl');
 moment.tz('Europe/Berlin').format('DD MMMM  YYYY');
@@ -61,6 +67,7 @@ export async function getAgendaInformationForNewsletter(meetingId) {
   }
 
   return {
+    meetingURI,
     formattedStart,
     formattedDocumentDate,
     meetingDate: meetingDate,
@@ -142,6 +149,33 @@ export async function getNewsletterByAgendaId(agendaUri) {
     ORDER BY ASC(?mandateePriority)`);
 
   return parseSparqlResults(newsletterInformation);
+}
+
+export async function createMailCampaign(meetingUri, mailCampaign) {
+  const {
+    campaignId,
+    web_id: webId,
+    archive_url: archiveUrl,
+  } = mailCampaign;
+  const id = uuid();
+
+  console.log(`Create mail campaign with id ${id} for meetingUri ${meetingUri}`);
+
+  const mailCampaignUri = `http://themis.vlaanderen.be/id/mailcampagne/${id}`;
+
+  await update(`
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+    INSERT DATA {
+      ${sparqlEscapeUri(meetingUri)} ext:heeftMailCampagnes ${sparqlEscapeUri(mailCampaignUri)} .
+      ${sparqlEscapeUri(mailCampaignUri)} a ext:MailCampagne ;
+        mu:uuid ${sparqlEscapeString(id)} ;
+        ext:campagneId ${sparqlEscapeString(campaignId)} ;
+        ext:campagneWebId ${sparqlEscapeString(String(webId))} ;
+        ext:voorbeeldUrl ${sparqlEscapeString(archiveUrl)} .
+    }`);
+  return id;
 }
 
 async function getMeetingURI (meetingId) {


### PR DESCRIPTION
Adds responsibility of creating/updating/deleting mail-campaign resources to the newsletter-service. This means that the frontend no longer needs to create and update the mail-campaign resources.

Also fixes a small issue in the mail-campaign deletion route where we used a non-existing wait function in case deletion failed.

:warning: The Mailchimp endpoints work based on the Mailchimp IDs, not the resource UUIDs. This is left unchanged in this PR, though we probably want to start using the resource UUIDs to be inline with how the rest of the app works.