### PR TITLE
KAS-4655: Check user is logged in before performing operations

### DIFF
--- a/util/session.js
+++ b/util/session.js
@@ -1,0 +1,37 @@
+import { query, sparqlEscapeUri } from 'mu';
+
+const ROLES = {
+  ADMIN: 'http://themis.vlaanderen.be/id/gebruikersrol/9a969b13-e80b-424f-8a82-a402bcb42bc5',
+  KANSELARIJ: 'http://themis.vlaanderen.be/id/gebruikersrol/ab39b02a-14a5-4aa9-90bd-e0fa268b0f3d',
+  SECRETARIE: 'http://themis.vlaanderen.be/id/gebruikersrol/c2ef1785-bf28-458f-952d-aa40989347d2',
+  KORT_BESTEK: 'http://themis.vlaanderen.be/id/gebruikersrol/ca20a872-7743-4998-b479-06b003f49daf',
+}
+
+async function sessionIsAuthorized(sessionUri) {
+  const roleUris = [
+    ROLES.ADMIN,
+    ROLES.KANSELARIJ,
+    ROLES.SECRETARIE,
+    ROLES.KORT_BESTEK,
+  ];
+
+  const queryString = `PREFIX session: <http://mu.semte.ch/vocabularies/session/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX org: <http://www.w3.org/ns/org#>
+
+ASK {
+  VALUES (?roleUri) {
+    ${roleUris.map(uri => `(${sparqlEscapeUri(uri)})`).join(`
+    `)}
+  }
+
+  ${sparqlEscapeUri(sessionUri)} session:account ?account ;
+    ext:sessionMembership / org:role ?roleUri .
+}`;
+  const response = await query(queryString);
+  return response.boolean;
+}
+
+export {
+  sessionIsAuthorized,
+}


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4655

This one is untested as I can't run the newsletter service locally without having the credentials to communicate with Mailchimp & Belga. Since it's the same style of code as the ones used in the other services, I think we can just merge this and test on ACC.