### PR TITLE
KAS-4997 add creation of a Belga Publication

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ import {
   deleteMailCampaign,
   getAgendaInformationForNewsletter,
   updateMailCampaignSentTime,
+  createBelgaPublication,
 } from './util/query-helper';
 import BelgaService from './repository/belga-service';
 import MailchimpService from './repository/mailchimp-service';
@@ -222,6 +223,7 @@ app.post('/belga-newsletters', async (req, res, next) => {
     try {
       const filePath = await belgaService.createBelgaNewsletterXML(meetingId);
       const belgaNewsletter = await belgaService.publishToBelga(filePath);
+      await createBelgaPublication(meetingId);
 
       res.status(201).send({
         data: {

--- a/util/query-helper.js
+++ b/util/query-helper.js
@@ -318,19 +318,6 @@ export async function createBelgaPublication(meetingId) {
 
   const belgaPublicationUri = `http://themis.vlaanderen.be/id/belga-publicatie/${id}`;
 
-  // TODO do we want to keep this? to allow fixes to be sent to Belga? one-to-one relation so need to delete unless we make it hasMany and sort on it
-  await update(`
-    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-
-    DELETE WHERE {
-      ${sparqlEscapeUri(meetingURI)} ext:heeftBelgaPublicatie ?belgaPublication .
-        ?belgaPublication a ext:BelgaPublicatie ;
-        mu:uuid ?id ;
-        ext:isVerstuurdOp ?datetime .
-    }`
-  );
-
   await update(`
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4997

- added a method to insert a `ext:BelgaPublication` with a `sent-at` date after Belga was sent out.
- also included a delete of `ext:BelgaPublication` in case there is ever a need to republish Belga (how does that even work?)
When Belga is republished, we will replace the file in the generated-xml folder, so there will be no proof of sending it unless in logs (or unless we keep a hasMany of `BelgaPublication` instead of one-to-one